### PR TITLE
Remove unused default filling

### DIFF
--- a/src/main/java/com/baerchen/central/authentication/client/boundary/RegisteredClientMapper.java
+++ b/src/main/java/com/baerchen/central/authentication/client/boundary/RegisteredClientMapper.java
@@ -6,7 +6,6 @@ import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 
-import java.time.Instant;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -39,37 +38,6 @@ public interface RegisteredClientMapper {
 
     default Set<String> toGrantTypeSet(Set<AuthorizationGrantType> input) {return input == null ? Set.of() : input.stream().map(AuthorizationGrantType::getValue).collect(Collectors.toSet());};
 
-    @AfterMapping
-    default void fillMissingDefaults(@MappingTarget RegisteredClient client) {
-        RegisteredClient.Builder builder = RegisteredClient.withId(UUID.randomUUID().toString());
-
-        if (client.getRedirectUris() == null) {
-            builder.redirectUris(Set::clear);
-        }
-        if (client.getScopes() == null) {
-            builder.scopes(Set::clear);
-        }
-        if (client.getAuthorizationGrantTypes() == null) {
-            builder.authorizationGrantTypes(Set::clear);
-        }
-
-        // Custom logic
-        if (client.getAuthorizationGrantTypes().contains("authorization_code")) {
-            //client.setRequireConsent(true);
-        }
-
-        // Maybe even default token TTLs
-        if (client.getClientIdIssuedAt()==null) {
-            builder.clientIdIssuedAt(Instant.now());
-        }
-
-
-        if (client.getTokenSettings()==null){
-            //a world to explore
-            //client.setRefreshTokenTTL(Duration.ofDays(30));
-        }
-        builder.build();
-    }
 
 
 }

--- a/src/main/java/com/baerchen/central/authentication/client/control/RegisteredClientAdminService.java
+++ b/src/main/java/com/baerchen/central/authentication/client/control/RegisteredClientAdminService.java
@@ -26,7 +26,6 @@ public class RegisteredClientAdminService {
 
     public RegisteredClientDTO create(RegisteredClientDTO dto){
         RegisteredClient rc = this.mapper.toEntity(dto,this.encoder);
-        this.mapper.fillMissingDefaults(rc);
         /*
         RegisteredClient rc = RegisteredClient.withId(UUID.randomUUID().toString())
                 .clientId(dto.clientId())


### PR DESCRIPTION
## Summary
- remove unused `fillMissingDefaults` method from mapper
- stop calling removed method in admin service

## Testing
- `mvnw -q test` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687acc760590832e9cfbeb9f0b8557db