### PR TITLE
Fix update endpoints and DB update

### DIFF
--- a/src/main/java/com/baerchen/central/authentication/registeredclient/boundary/RegisteredClientAdminController.java
+++ b/src/main/java/com/baerchen/central/authentication/registeredclient/boundary/RegisteredClientAdminController.java
@@ -50,11 +50,22 @@ public class RegisteredClientAdminController {
         return ResponseEntity.ok(this.service.updateByClientId(dto));
     }
 
-    public ResponseEntity<RegisteredClientDTO> updateById(@RequestBody RegisteredClientDTO dto){
-        String client = this.service.getById(dto.clientId()).map(RegisteredClientDTO::id).stream().findFirst().orElseThrow(() ->
-                new ResponseStatusException(HttpStatus.NOT_FOUND, String.format("Client not found: [%s]", dto.clientId()))
+    @PutMapping("/id/{id}")
+    public ResponseEntity<RegisteredClientDTO> updateById(@PathVariable String id, @RequestBody RegisteredClientDTO dto){
+        this.service.getById(id).orElseThrow(() ->
+                new ResponseStatusException(HttpStatus.NOT_FOUND, String.format("Client not found: [%s]", id))
         );
-        return ResponseEntity.ok(this.service.updateById(dto));
+        RegisteredClientDTO updated = new RegisteredClientDTO(
+                id,
+                dto.clientId(),
+                dto.clientSecret(),
+                dto.redirectUris(),
+                dto.scopes(),
+                dto.authenticationMethods(),
+                dto.grantTypes(),
+                dto.clientSettings()
+        );
+        return ResponseEntity.ok(this.service.updateById(updated));
     }
 
 }

--- a/src/main/java/com/baerchen/central/authentication/registeredclient/control/CustomRegisteredClientRepo.java
+++ b/src/main/java/com/baerchen/central/authentication/registeredclient/control/CustomRegisteredClientRepo.java
@@ -32,7 +32,15 @@ public class CustomRegisteredClientRepo implements Parser {
 
     public void updateClientById(RegisteredClient client){
        var sql = "UPDATE oauth2_registered_client SET client_authentication_methods = ?, authorization_grant_types = ?, redirect_uris = ?, scopes = ?, client_settings = ? WHERE id = ?";
-        this.jdbcTemplate.update(sql, client.getClientAuthenticationMethods(), client.getAuthorizationGrantTypes(), client.getRedirectUris(), client.getScopes(), client.getClientSettings(), client.getId());
+        this.jdbcTemplate.update(
+                sql,
+                parse(client.getClientAuthenticationMethods(), ClientAuthenticationMethod::getValue),
+                parse(client.getAuthorizationGrantTypes(), AuthorizationGrantType::getValue),
+                parse(client.getRedirectUris(), t -> "" + t),
+                parse(client.getScopes(), t -> "" + t),
+                convertToDatabaseColumn(client.getClientSettings().getSettings()),
+                client.getId()
+        );
     }
 
     public void updateClientByClientId(RegisteredClient client) {


### PR DESCRIPTION
## Summary
- correct SQL update for client by ID
- expose endpoint for updating clients by numeric ID in admin controller

## Testing
- `mvn -q -DskipTests package` *(fails: Failed to fetch https://repo.maven.apache.org/... due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_687be51df9cc832ea4cfd93af0c6de2e