### PR TITLE
Improve token customization and registered client retrieval

### DIFF
--- a/src/main/java/com/baerchen/central/authentication/oauth/boundary/JwtTokenCustomizer.java
+++ b/src/main/java/com/baerchen/central/authentication/oauth/boundary/JwtTokenCustomizer.java
@@ -1,7 +1,7 @@
 package com.baerchen.central.authentication.oauth.boundary;
 
 import com.baerchen.central.authentication.userregister.control.UserRepository;
-import com.baerchen.central.authentication.userregister.entity.User;
+import java.util.Optional;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.oauth2.server.authorization.token.JwtEncodingContext;
 import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenCustomizer;
@@ -12,15 +12,10 @@ public class JwtTokenCustomizer {
 
     @Bean
     public OAuth2TokenCustomizer<JwtEncodingContext> tokenCustomizer(UserRepository userRepository){
-        return context -> {
-            if (context.getPrincipal() != null && context.getPrincipal().getName()!=null) {
-                String username = context.getPrincipal().getName();
-                User user = userRepository.findByUsername(username).orElse(null);
-                if (user != null){
-                    context.getClaims().claim("roles", user.getRoles());
-                }
-            }
-        };
+        return context -> Optional.ofNullable(context.getPrincipal())
+                .map(principal -> principal.getName())
+                .flatMap(userRepository::findByUsername)
+                .ifPresent(user -> context.getClaims().claim("roles", user.getRoles()));
     }
 
 

--- a/src/main/java/com/baerchen/central/authentication/oauth/control/RolesClaimConverter.java
+++ b/src/main/java/com/baerchen/central/authentication/oauth/control/RolesClaimConverter.java
@@ -5,21 +5,20 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class RolesClaimConverter implements Converter<Jwt, Collection<GrantedAuthority>> {
 
     @Override
     public Collection<GrantedAuthority> convert(Jwt source) {
-        Collection<GrantedAuthority> authorities = new ArrayList<>();
         List<String> roles = source.getClaimAsStringList("roles");
-        if (roles != null){
-            for (String role: roles){
-                authorities.add(new SimpleGrantedAuthority("ROLE_"+role));
-            }
+        if (roles == null || roles.isEmpty()) {
+            return List.of();
         }
-        return authorities;
+        return roles.stream()
+                .map(role -> new SimpleGrantedAuthority("ROLE_" + role))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/baerchen/central/authentication/registeredclient/control/CustomRegisteredClientRepo.java
+++ b/src/main/java/com/baerchen/central/authentication/registeredclient/control/CustomRegisteredClientRepo.java
@@ -4,6 +4,7 @@ import com.baerchen.central.authentication.registeredclient.boundary.RegisteredC
 import com.baerchen.central.authentication.runtime.control.Parser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.type.TypeReference;
 import lombok.AllArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
@@ -42,7 +43,7 @@ public class CustomRegisteredClientRepo implements Parser {
 
     public List<RegisteredClientDTO> listAllClients() {
         return jdbcTemplate.query(
-                "SELECT id, client_id, client_secret, redirect_uris, scopes, client_authentication_methods, authorization_grant_types FROM oauth2_registered_client",
+                "SELECT id, client_id, client_secret, redirect_uris, scopes, client_authentication_methods, authorization_grant_types, client_settings FROM oauth2_registered_client",
                 (rs, rowNum) -> new RegisteredClientDTO(
                         rs.getString("id"),
                         rs.getString("client_id"),
@@ -51,7 +52,7 @@ public class CustomRegisteredClientRepo implements Parser {
                         parseSet(rs.getString("scopes")),
                         parseSet(rs.getString("client_authentication_methods")),
                         parseSet(rs.getString("authorization_grant_types")),
-                        Map.of() //TO-DO implement parseMap
+                        parseMap(rs.getString("client_settings"))
         ));
     }
 
@@ -60,6 +61,17 @@ public class CustomRegisteredClientRepo implements Parser {
             return objectMapper.writeValueAsString(attribute);
         } catch (JsonProcessingException e) {
             throw new IllegalArgumentException("Could not serialize clientSettings", e);
+        }
+    }
+
+    private Map<String, Object> parseMap(String json) {
+        if (json == null || json.isBlank()) {
+            return Map.of();
+        }
+        try {
+            return objectMapper.readValue(json, new TypeReference<Map<String, Object>>() {});
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("Could not deserialize clientSettings", e);
         }
     }
 }


### PR DESCRIPTION
## Summary
- parse client_settings JSON in `CustomRegisteredClientRepo`
- simplify `RolesClaimConverter` with streams
- streamline `JwtTokenCustomizer`

## Testing
- `./mvnw -q -DskipTests package` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687be51df9cc832ea4cfd93af0c6de2e