### PR TITLE
chore: add dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,32 @@
+# Maven build output
+target/
+**/target/
+
+# Git repositories
+.git
+.gitignore
+
+# Maven Wrapper
+.mvn/
+mvnw
+mvnw.cmd
+
+# IDE directories and project files
+.idea/
+.vscode/
+*.iml
+*.ipr
+*.iws
+
+# Environment files
+.env
+.env-dev
+.env.prod
+.env-test
+
+# Docker and Compose artifacts
+compose.yaml
+dockerrun.txt
+
+# Miscellaneous
+backup


### PR DESCRIPTION
## Summary
- add `.dockerignore` to exclude build output, vcs, IDE, env files from Docker build context

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_688d6b5b5354832ebf320ca737b22200