### PR TITLE
Use JRE base image and run as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,17 @@ COPY src ./src
 RUN mvn clean package -DskipTests
 
 # === Stage 2: Run ===
-FROM eclipse-temurin:21-jdk-alpine
+FROM eclipse-temurin:21-jre-alpine
 
 WORKDIR /app
 
+# Create and use non-root user
+RUN addgroup -S app && adduser -S app -G app
+
 COPY --from=builder /app/target/*.jar app.jar
+RUN chown app:app app.jar
+
+USER app
 
 EXPOSE 9090
 


### PR DESCRIPTION
## Summary
- switch runtime image to eclipse-temurin JRE
- add non-root user and ensure jar is readable

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.10/apache-maven-3.9.10-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_688d6b7ca0b0832e94ad86e63fc924b9