### PR TITLE
refactor: streamline docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,33 +1,27 @@
-# Maven build output
-target/
+## Build output
 **/target/
 
-# Git repositories
+## Git
 .git
 .gitignore
 
-# IDE directories and project files
+## IDE directories and project files
 .idea/
 .vscode/
 *.iml
 *.ipr
 *.iws
 
-# Environment files
+## Environment files
 .env
 .env-dev
 .env.prod
 .env-test
 
-# Docker and Compose artifacts
+## Docker artifacts
 compose.yaml
 
-# Miscellaneous
+## Miscellaneous
 backup
-
-target/
-.git/
-.idea/
-*.iml
 *.log
 *.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,14 @@
 # Builder
 FROM maven:3.9.6-eclipse-temurin-21 AS builder
 WORKDIR /app
-COPY .mvn .mvn
-COPY mvnw .
-COPY pom.xml .
+COPY pom.xml ./
+RUN mvn dependency:go-offline -B
 COPY src ./src
-
-RUN ./mvnw clean package -DskipTests
+RUN mvn clean package -DskipTests -B
 
 # Runtime
 FROM eclipse-temurin:21-jre-alpine
 WORKDIR /app
 COPY --from=builder /app/target/*.jar app.jar
-
-# Accept build-time arguments
-ARG SPRING_DATASOURCE_URL
-ARG SPRING_DATASOURCE_USERNAME
-ARG SPRING_DATASOURCE_PASSWORD
-ARG DB
-ARG DB_PASSWORD
-ARG APP
-ARG APP_PASSWORD
-
-# Export them as ENV variables
-ENV SPRING_DATASOURCE_URL=${SPRING_DATASOURCE_URL}
-ENV SPRING_DATASOURCE_USERNAME=${SPRING_DATASOURCE_USERNAME}
-ENV SPRING_DATASOURCE_PASSWORD=${SPRING_DATASOURCE_PASSWORD}
-ENV DB=${DB}
-ENV DB_PASSWORD=${DB_PASSWORD}
-ENV APP=${APP}
-ENV APP_PASSWORD=${APP_PASSWORD}
 
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,13 +8,9 @@ services:
     environment:
       SPRING_DATASOURCE_URL: ${SPRING_DATASOURCE_URL}
       SPRING_DATASOURCE_USERNAME: cauth
-      SPRING_DATASOURCE_PASSWORD: 1234567
+      SPRING_DATASOURCE_PASSWORD: ${SPRING_DATASOURCE_PASSWORD}
       LIQUIBASE_URL: jdbc:postgresql://pg-4kgbbad-5:5432/postgres
       DB_PASSWORD: ${DB_PASSWORD}
-
-volumes:
-  pg-4kgbbad-vol:
-    name: pg-4kgbbad-vol
 
 networks:
   4kgbbad-net:


### PR DESCRIPTION
## Summary
- simplify Dockerfile and pre-fetch dependencies for faster builds
- remove redundant entries in .dockerignore
- drop unused compose volume and avoid hardcoded DB password

## Testing
- `mvn -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6892eca83d04832e946af37e527bc250